### PR TITLE
refer to pollenprognos-card in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@ This integration can be configured via the Home Assistant frontend.
 - Search and select the **Pollenprognos** integration form the list.
 - Follow the instruction on screen to add the sensors.
 
-[Lovelace card to use with this integration.](https://github.com/krissen/pollenprognos-card)
+### Lovelace
+
+- [pollenprognos-card](https://github.com/krissen/pollenprognos-card) works with the current version (>=v1.1.0) of the integration, as well as earlier versions.
+- [lovelace-pollenprognos-card](https://github.com/isabellaalstrom/lovelace-pollenprognos-card) works with versions prior to v1.1.0 of the integration.
 
 ### Disclaimer
 This integration is not affiliated with Pollenrapporten.se

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This integration can be configured via the Home Assistant frontend.
 - Search and select the **Pollenprognos** integration form the list.
 - Follow the instruction on screen to add the sensors.
 
-[Lovelace card to use with this integration.](https://github.com/isabellaalstrom/lovelace-pollenprognos-card)
+[Lovelace card to use with this integration.](https://github.com/krissen/pollenprognos-card)
 
 ### Disclaimer
 This integration is not affiliated with Pollenrapporten.se


### PR DESCRIPTION
Might I be so bold as to suggest you'd refer to [pollenprognos-card](https://github.com/krissen/pollenprognos-card/) in the README instead of [lovelace-pollenprognos-card](https://github.com/isabellaalstrom/lovelace-pollenprognos-card), which hasn't been updated in three years.

The latter probably doesn't work with the current version of the sensor. Version v1.0.6 of `pollenprognos-card` has now been released, with support for the current format of the sensor attributes of this integration. Let me know if you want me to amend it, so as to keep a reference to the prior lovelace card as well (but again, seeing at it hasn't been updated in three years, it won't work with the current version of this integration).

Issue #73.